### PR TITLE
refactor: replace class components with functions

### DIFF
--- a/cms/previews/IndexPreviewComponent.tsx
+++ b/cms/previews/IndexPreviewComponent.tsx
@@ -1,5 +1,5 @@
 import { PreviewTemplateComponentProps } from 'netlify-cms-core';
-import React, { Component } from 'react';
+import React from 'react';
 import IndexComponent from '../../components/page/IndexComponent';
 
 /**
@@ -7,29 +7,31 @@ import IndexComponent from '../../components/page/IndexComponent';
  * backend data to the component props.
  * See: https://www.netlifycms.org/docs/customization/
  */
-export default class IndexPreviewComponent extends Component<PreviewTemplateComponentProps> {
-  render(): JSX.Element {
-    const title = this.props.entry.getIn(['data', 'title']);
+const IndexPreviewComponent: React.FC<PreviewTemplateComponentProps> = (
+  props,
+) => {
+  const title = props.entry.getIn(['data', 'title']);
 
-    const intro = this.props.entry.getIn(['data', 'intro']);
+  const intro = props.entry.getIn(['data', 'intro']);
 
-    /**
-     * Example of loading in a collection from the CMS data
-     */
-    const features = this.props.entry.getIn(['data', 'features']).toJS();
+  /**
+   * Example of loading in a collection from the CMS data
+   */
+  const features = props.entry.getIn(['data', 'features']).toJS();
 
-    const gallery = this.props.entry.getIn(['data', 'gallery']).toJS();
+  const gallery = props.entry.getIn(['data', 'gallery']).toJS();
 
-    return (
-      // Send the props down into the component.
-      <div className={'p-5'}>
-        <IndexComponent
-          title={title}
-          intro={intro}
-          features={features}
-          gallery={gallery}
-        />
-      </div>
-    );
-  }
-}
+  return (
+    // Send the props down into the component.
+    <div className={'p-5'}>
+      <IndexComponent
+        title={title}
+        intro={intro}
+        features={features}
+        gallery={gallery}
+      />
+    </div>
+  );
+};
+
+export default IndexPreviewComponent;

--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -1,18 +1,12 @@
-import { Component } from 'react';
-
-export default class Footer extends Component {
-  getYear(): number {
-    return new Date().getFullYear();
-  }
-
-  render(): JSX.Element {
-    return (
+const FooterComponent: React.FC = () => {
+  return (
+    <div>
       <div>
-        <div>
-          &copy; {this.getYear()} The Jamie Smyth Groups, LLC All rights
-          reserved
-        </div>
+        &copy; {new Date().getFullYear()} The Jamie Smyth Groups, LLC All rights
+        reserved
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+export default FooterComponent;

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -1,16 +1,14 @@
-import { Component } from 'react';
+const HeaderComponent: React.FC = () => {
+  return (
+    <div className={'py-8 flex flex-row justify items-center'}>
+      <img
+        className={'inline-block w-24 rounded-full border border-gray-light'}
+        src={'assets/images/tsg_icon_large.png'}
+        alt={'The Smyth Group logo'}
+      />
+      <span className={'px-8 text-3xl font-bold'}>The Smyth Group</span>
+    </div>
+  );
+};
 
-export default class header extends Component {
-  render(): JSX.Element {
-    return (
-      <div className={'py-8 flex flex-row justify items-center'}>
-        <img
-          className={'inline-block w-24 rounded-full border border-gray-light'}
-          src={'assets/images/tsg_icon_large.png'}
-          alt={'The Smyth Group logo'}
-        />
-        <span className={'px-8 text-3xl font-bold'}>The Smyth Group</span>
-      </div>
-    );
-  }
-}
+export default HeaderComponent;

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,17 +1,19 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Header from './header/Header';
 import Footer from './footer/Footer';
 
-export default class Layout extends Component {
-  render(): JSX.Element {
-    const { children } = this.props;
-
-    return (
-      <div className='container mx-auto px-2'>
-        <Header />
-        <main>{children}</main>
-        <Footer />
-      </div>
-    );
-  }
+interface LayoutProps {
+  children: React.ReactNode;
 }
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  return (
+    <div className='container mx-auto px-2'>
+      <Header />
+      <main>{children}</main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Layout;

--- a/components/page/IndexComponent.tsx
+++ b/components/page/IndexComponent.tsx
@@ -1,4 +1,3 @@
-import { Component } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 export interface IndexFeature {
@@ -17,44 +16,49 @@ export interface IndexComponentProps {
   gallery: IndexGalleryImage[];
 }
 
-export default class IndexPageComponent extends Component<IndexComponentProps> {
-  render(): JSX.Element {
-    return (
-      <div>
-        <h1 className={'text-2xl mb-8'}>{this.props.title}</h1>
-        <div className={'mb-8'}>{this.props.intro}</div>
-        <div className={'md:grid grid-cols-3 mb-8 gap-4'}>
-          {this.props.features.map((feature, i) => {
-            return (
-              <div key={i}>
-                <h2 className={'text-xl mb-4'}>{feature.title}</h2>
-                <div>
-                  <ReactMarkdown children={feature.content} />
-                </div>
+const IndexPageComponent: React.FC<IndexComponentProps> = ({
+  title,
+  intro,
+  features,
+  gallery,
+}) => {
+  return (
+    <div>
+      <h1 className={'text-2xl mb-8'}>{title}</h1>
+      <div className={'mb-8'}>{intro}</div>
+      <div className={'md:grid grid-cols-3 mb-8 gap-4'}>
+        {features.map((feature, i) => {
+          return (
+            <div key={i}>
+              <h2 className={'text-xl mb-4'}>{feature.title}</h2>
+              <div>
+                <ReactMarkdown children={feature.content} />
               </div>
-            );
-          })}
-        </div>
-        <div>
-          <h2 className={'text-2xl mb-8'}>Arrange Content To Your Liking</h2>
-          <p className={'mb-8'}>
-            Provide rich experiences and accurate information.
-          </p>
-        </div>
-        <div className={'grid grid-cols-3'}>
-          {this.props.gallery.map((item, i) => {
-            return (
-              <div key={i} className={'relative overflow-hidden'}>
-                <img
-                  className={'scale-150 h-full w-fit'}
-                  src={item.image}
-                  alt={'In production this should have real alt text'}
-                />
-              </div>
-            );
-          })}
-        </div>
+            </div>
+          );
+        })}
       </div>
-    );
-  }
-}
+      <div>
+        <h2 className={'text-2xl mb-8'}>Arrange Content To Your Liking</h2>
+        <p className={'mb-8'}>
+          Provide rich experiences and accurate information.
+        </p>
+      </div>
+      <div className={'grid grid-cols-3'}>
+        {gallery.map((item, i) => {
+          return (
+            <div key={i} className={'relative overflow-hidden'}>
+              <img
+                className={'scale-150 h-full w-fit'}
+                src={item.image}
+                alt={'In production this should have real alt text'}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default IndexPageComponent;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,26 +1,30 @@
-import { Component } from 'react';
+import { GetStaticPropsResult } from 'next';
 import IndexComponent, {
   IndexComponentProps,
 } from '../components/page/IndexComponent';
 import CollectionService from '../lib/CollectionService';
 
-export default class IndexPageView extends Component<IndexComponentProps> {
-  render(): JSX.Element {
-    const { title, intro, features, gallery } = this.props;
-    return (
-      <div>
-        <IndexComponent
-          title={title}
-          intro={intro}
-          features={features}
-          gallery={gallery}
-        />
-      </div>
-    );
-  }
-}
+const IndexPage: React.FC<IndexComponentProps> = ({
+  title,
+  intro,
+  features,
+  gallery,
+}) => {
+  return (
+    <>
+      <IndexComponent
+        title={title}
+        intro={intro}
+        features={features}
+        gallery={gallery}
+      />
+    </>
+  );
+};
 
-export function getStaticProps() {
+export default IndexPage;
+
+export function getStaticProps(): GetStaticPropsResult<IndexComponentProps> {
   const markdownCollection = new CollectionService<IndexComponentProps>(
     './content/home.md',
   );


### PR DESCRIPTION
This may be controversial, but FunctionComponents seem to be
the "future" in React-world. Let's try to keep up.

@pbredenberg You don't need to feel compelled to accept this if you don't want this to be the standard on all future projects.