### PR TITLE
feat: add "relation" widget example

### DIFF
--- a/cms/config/index.ts
+++ b/cms/config/index.ts
@@ -29,7 +29,7 @@ type CustomCmsCollectionFiles = Modify<
 >;
 type CustomCmsCollection = Modify<
   CmsCollection,
-  { files: CustomCmsCollectionFiles[] }
+  { files?: CustomCmsCollectionFiles[] }
 >;
 type CustomCmsConfig = Modify<
   CmsConfig,
@@ -145,6 +145,27 @@ export const cmsConfig: CustomCmsConfig = {
 
         // Example page to showcase all widgets.
         widgetShowcasePage,
+      ],
+    },
+    // This collection is used to show off the "relation" widget in the
+    // WidgetShowcasePage.
+    {
+      label: 'Sales Offices',
+      name: 'sales-offices',
+      folder: 'content/sales-offices',
+      create: true,
+      fields: [
+        {
+          label: 'Name',
+          name: 'title',
+          widget: 'string',
+        },
+        {
+          label: 'Address',
+          name: 'address',
+          widget: 'string',
+        },
+        { label: 'Description', name: 'description', widget: 'markdown' },
       ],
     },
   ],

--- a/cms/config/widget-showcase-page.ts
+++ b/cms/config/widget-showcase-page.ts
@@ -140,5 +140,28 @@ export const widgetShowcasePage: CmsCollectionFile = {
       name: 'code',
       widget: 'code',
     },
+
+    // Referencing a file collection list field example
+    {
+      label: 'Promoted Feature',
+      name: 'promotedFeature',
+      widget: 'relation',
+      collection: 'pages',
+      file: 'home',
+      search_fields: ['features.*.title'],
+      value_field: 'features.*.title',
+      display_fields: ['features.*.title'],
+    },
+
+    // Referencing a folder collection field example
+    {
+      label: 'Featured Location',
+      name: 'featuredLocation',
+      widget: 'relation',
+      collection: 'sales-offices',
+      search_fields: ['address'],
+      value_field: 'address',
+      display_fields: ['{{title}} ({{address}})'],
+    },
   ],
 };


### PR DESCRIPTION
This commit adds an example to show how to work with the relation
widget.

The documentation can be found here:
https://www.netlifycms.org/docs/widgets/#relation
